### PR TITLE
Using variable named defaultStyles broke things for expo 🤯

### DIFF
--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -9,7 +9,8 @@ interface ButtonProps {
   style?: any;
 }
 
-const defaultStyles = css.create({
+// Do not name this variable "defaultStyles" 🤯
+const defaultStyles_NOPE = css.create({
   button: {
     padding: 4,
     color: 'white',
@@ -23,13 +24,13 @@ const defaultStyles = css.create({
 });
 
 export function Button({ children, onClick, style = {} }: ButtonProps) {
-  console.log("defaultStyles.button:", defaultStyles.button);
-  console.log("incoming style:", style);
-  console.log("combined style array:", [defaultStyles.button, style]);
+  console.log("defaults:", defaultStyles_NOPE.button);
+  console.log("incoming:", style);
+  console.log("combined:", [defaultStyles_NOPE.button, style]);
 
   return (
     <html.button
-      style={[defaultStyles.button, style]}
+      style={[defaultStyles_NOPE.button, style]}
       onClick={onClick}
     >
       {children}


### PR DESCRIPTION
Apparently Expo and styledx build process really didn't like style variable with the name "defaultStyles", as it caused Expo to not use any of the defaults defined in the `packages/ui/src/button.tsx` component

# Next (web) with either defaultStyles or defaultStyles_NOPE variable name
![Screenshot 2025-03-13 at 17 42 47](https://github.com/user-attachments/assets/3b3c0794-1e47-4527-be08-59ce91f07ce2)

This works regardless of the variable name choice
```
defaults: {
  'button___defaultStyles.button': 'button___defaultStyles.button',
  padding: 'padding-xfawy5m',
  color: 'color-x1awj2ng',
  backgroundColor: 'backgroundColor-x1u857p9',
  borderRadius: 'borderRadius-x12oqio5',
  borderWidth: 'borderWidth-x6h9yrm',
  borderStyle: 'borderStyle-xbsl7fq',
  borderColor: 'borderColor-x1657c11',
  fontSize: 'fontSize-xwsyq91',
  '$$css': true
}
incoming: {
  'page__moreStyles.button': 'page__moreStyles.button',
  fontSize: 'fontSize-xyywni2',
  cursor: 'cursor-x1ypdohk',
  backgroundColor: 'backgroundColor-x1t391ir',
  '$$css': true
}
combined: [
  {
    'button___defaultStyles.button': 'button___defaultStyles.button',
    padding: 'padding-xfawy5m',
    color: 'color-x1awj2ng',
    backgroundColor: 'backgroundColor-x1u857p9',
    borderRadius: 'borderRadius-x12oqio5',
    borderWidth: 'borderWidth-x6h9yrm',
    borderStyle: 'borderStyle-xbsl7fq',
    borderColor: 'borderColor-x1657c11',
    fontSize: 'fontSize-xwsyq91',
    '$$css': true
  },
  {
    'page__moreStyles.button': 'page__moreStyles.button',
    fontSize: 'fontSize-xyywni2',
    cursor: 'cursor-x1ypdohk',
    backgroundColor: 'backgroundColor-x1t391ir',
    '$$css': true
  }
]
```

# Expo (mobile) w/ "defaultStyles" variable name
Naming the variable `defaultStyles` meant the default styles didn't get picked up when the component was used in consuming app.
![Screenshot 2025-03-13 at 17 42 58](https://github.com/user-attachments/assets/2d15a52c-8e4a-443f-8427-bf51d72897bf)

```
λ  LOG  defaults: [
  {
    'runtime__styles.inlineblock': 'runtime__styles.inlineblock',
    borderStyle: 'borderStyle-x1y0btm7',
    margin: 'margin-x1ghz6dp',
    padding: 'padding-x1717udv',
    '$$css': true
  },
  {
    'runtime__styles.button': 'runtime__styles.button',
    borderWidth: 'borderWidth-xmkeg23',
    '$$css': true
  }
]
λ  LOG  incoming: {
  'index__styles.button': 'index__styles.button',
  fontSize: 'fontSize-xyywni2',
  cursor: 'cursor-x1ypdohk',
  backgroundColor: 'backgroundColor-x1t391ir',
  '$$css': true
}
λ  LOG  combined: [
  [
    {
      'runtime__styles.inlineblock': 'runtime__styles.inlineblock',
      borderStyle: 'borderStyle-x1y0btm7',
      margin: 'margin-x1ghz6dp',
      padding: 'padding-x1717udv',
      '$$css': true
    },
    {
      'runtime__styles.button': 'runtime__styles.button',
      borderWidth: 'borderWidth-xmkeg23',
      '$$css': true
    }
  ],
  {
    'index__styles.button': 'index__styles.button',
    fontSize: 'fontSize-xyywni2',
    cursor: 'cursor-x1ypdohk',
    backgroundColor: 'backgroundColor-x1t391ir',
    '$$css': true
  }
]
```

# Expo (mobile) w/ "defaultStyles_NOPE" variable name
Changing the variable name to *anything* other than `defaultStyles` fixes things in Expo 😭 
![Screenshot 2025-03-13 at 17 49 52](https://github.com/user-attachments/assets/4efb7670-9b7a-4ff6-9b06-489d45a141d3)

```
λ  LOG  defaults: {
  'button__defaultStyles_NOPE.button': 'button__defaultStyles_NOPE.button',
  padding: 'padding-xfawy5m',
  color: 'color-x1awj2ng',
  backgroundColor: 'backgroundColor-x1u857p9',
  borderRadius: 'borderRadius-x12oqio5',
  borderWidth: 'borderWidth-x6h9yrm',
  borderStyle: 'borderStyle-xbsl7fq',
  borderColor: 'borderColor-x1657c11',
  fontSize: 'fontSize-xwsyq91',
  '$$css': true
}
λ  LOG  incoming: {
  'index__styles.button': 'index__styles.button',
  fontSize: 'fontSize-xyywni2',
  cursor: 'cursor-x1ypdohk',
  backgroundColor: 'backgroundColor-x1t391ir',
  '$$css': true
}
λ  LOG  combined: [
  {
    'button__defaultStyles_NOPE.button': 'button__defaultStyles_NOPE.button',
    padding: 'padding-xfawy5m',
    color: 'color-x1awj2ng',
    backgroundColor: 'backgroundColor-x1u857p9',
    borderRadius: 'borderRadius-x12oqio5',
    borderWidth: 'borderWidth-x6h9yrm',
    borderStyle: 'borderStyle-xbsl7fq',
    borderColor: 'borderColor-x1657c11',
    fontSize: 'fontSize-xwsyq91',
    '$$css': true
  },
  {
    'index__styles.button': 'index__styles.button',
    fontSize: 'fontSize-xyywni2',
    cursor: 'cursor-x1ypdohk',
    backgroundColor: 'backgroundColor-x1t391ir',
    '$$css': true
  }
]
```